### PR TITLE
Fix valgrind's memcpy warning.

### DIFF
--- a/qat_ciphers.c
+++ b/qat_ciphers.c
@@ -432,7 +432,7 @@ static int cipher_init_chained(EVP_CIPHER_CTX *evp_ctx,
     }
 
     if (NULL != iv)
-        memcpy(EVP_CIPHER_CTX_iv_noconst(evp_ctx), iv, EVP_CIPHER_CTX_iv_length(evp_ctx));
+        memmove(EVP_CIPHER_CTX_iv_noconst(evp_ctx), iv, EVP_CIPHER_CTX_iv_length(evp_ctx));
     else
         memset(EVP_CIPHER_CTX_iv_noconst(evp_ctx), 0, EVP_CIPHER_CTX_iv_length(evp_ctx));
 
@@ -458,7 +458,7 @@ static int cipher_init_chained(EVP_CIPHER_CTX *evp_ctx,
         goto end;
     }
 
-    memcpy(qat_ctx->session_data->cipherSetupData.pCipherKey, key,
+    memmove(qat_ctx->session_data->cipherSetupData.pCipherKey, key,
            EVP_CIPHER_CTX_key_length(evp_ctx));
 
     /* Operation to perform */
@@ -691,7 +691,7 @@ int qat_aes_cbc_hmac_sha_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
                         authModeSetupData.authKeyLenInBytes = HMAC_KEY_SIZE;
                 }   
             } else {
-                memcpy(hmac_key, ptr, arg);
+                memmove(hmac_key, ptr, arg);
                 sessionSetupData->hashSetupData.
                     authModeSetupData.authKeyLenInBytes = arg;
             }
@@ -742,7 +742,7 @@ int qat_aes_cbc_hmac_sha_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
                  * sized buffer so that the header is in the final part
                  * of the buffer
                  */
-                memcpy(evp_ctx->tls_virt_hdr +
+                memmove(evp_ctx->tls_virt_hdr +
                         (QAT_BYTE_ALIGNMENT - TLS_VIRT_HDR_SIZE), p,
                         TLS_VIRT_HDR_SIZE);
                 DUMPL("tls_virt_hdr",
@@ -760,7 +760,7 @@ int qat_aes_cbc_hmac_sha_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
                  */
                 if (arg > TLS_VIRT_HDR_SIZE)
                     arg = TLS_VIRT_HDR_SIZE;
-                memcpy(evp_ctx->tls_virt_hdr +
+                memmove(evp_ctx->tls_virt_hdr +
                         (QAT_BYTE_ALIGNMENT - TLS_VIRT_HDR_SIZE), ptr,
                         arg);
                 evp_ctx->payload_length = arg;
@@ -1114,7 +1114,7 @@ int qat_aes_cbc_hmac_sha_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         return 0;
     } else if (evp_ctx->tls_version >= TLS1_1_VERSION) {
         iv = AES_BLOCK_SIZE;
-        memcpy(evp_ctx->OpData.pIv, in, EVP_CIPHER_CTX_iv_length(ctx));
+        memmove(evp_ctx->OpData.pIv, in, EVP_CIPHER_CTX_iv_length(ctx));
         /*
          * Note: The OpenSSL framework assumes that the IV field will be part
          * of the encrypted data, yet never looks at the output of the
@@ -1124,14 +1124,14 @@ int qat_aes_cbc_hmac_sha_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
          * field in encryption
          */
         if (in != out)
-            memcpy(out, in, EVP_CIPHER_CTX_iv_length(ctx));
+            memmove(out, in, EVP_CIPHER_CTX_iv_length(ctx));
         in += iv;
         out += iv;
         len -= iv;
         evp_ctx->payload_length -= iv;
         plen -= iv;
     } else {
-        memcpy(evp_ctx->OpData.pIv, EVP_CIPHER_CTX_iv(ctx), EVP_CIPHER_CTX_iv_length(ctx));
+        memmove(evp_ctx->OpData.pIv, EVP_CIPHER_CTX_iv(ctx), EVP_CIPHER_CTX_iv_length(ctx));
     }
 
     /* Build request/response buffers */
@@ -1146,7 +1146,7 @@ int qat_aes_cbc_hmac_sha_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             return 0;
         }
         evp_ctx->dstFlatBuffer[1].pData = evp_ctx->srcFlatBuffer[1].pData;
-        memcpy(evp_ctx->dstFlatBuffer[1].pData, in, len);
+        memmove(evp_ctx->dstFlatBuffer[1].pData, in, len);
     }
     evp_ctx->srcFlatBuffer[1].dataLenInBytes = len;
     evp_ctx->srcBufferList.pUserData = NULL;
@@ -1168,8 +1168,8 @@ int qat_aes_cbc_hmac_sha_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         unsigned char out_blk[AES_BLOCK_SIZE] = { 0x0 };
 
         key_len = key_len * 8;  /* convert to bits */
-        memcpy(in_blk, (in + (len - AES_BLOCK_SIZE)), AES_BLOCK_SIZE);
-        memcpy(ivec, (in + (len - (AES_BLOCK_SIZE + AES_BLOCK_SIZE))),
+        memmove(in_blk, (in + (len - AES_BLOCK_SIZE)), AES_BLOCK_SIZE);
+        memmove(ivec, (in + (len - (AES_BLOCK_SIZE + AES_BLOCK_SIZE))),
                AES_BLOCK_SIZE);
 
         /* Dump input parameters */
@@ -1206,7 +1206,7 @@ int qat_aes_cbc_hmac_sha_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         evp_ctx->OpData.messageLenToHashInBytes =
             TLS_VIRT_HDR_SIZE + evp_ctx->payload_length;
         /* Only copy the offset header data itself and not the whole block */
-        memcpy(evp_ctx->dstFlatBuffer[0].pData +
+        memmove(evp_ctx->dstFlatBuffer[0].pData +
                (QAT_BYTE_ALIGNMENT - TLS_VIRT_HDR_SIZE),
                evp_ctx->tls_virt_hdr + (QAT_BYTE_ALIGNMENT -
                                         TLS_VIRT_HDR_SIZE),
@@ -1234,7 +1234,7 @@ int qat_aes_cbc_hmac_sha_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     if (!EVP_CIPHER_CTX_encrypting(ctx) &&
         (NO_PAYLOAD_LENGTH_SPECIFIED != evp_ctx->payload_length) &&
         ((evp_ctx->tls_version) < TLS1_1_VERSION))
-        memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), in + len - AES_BLOCK_SIZE,
+        memmove(EVP_CIPHER_CTX_iv_noconst(ctx), in + len - AES_BLOCK_SIZE,
                EVP_CIPHER_CTX_iv_length(ctx));
 
     CRYPTO_QAT_LOG("CIPHER - %s\n", __func__);
@@ -1283,13 +1283,13 @@ int qat_aes_cbc_hmac_sha_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     DEBUG("Post Perform Op\n");
 
     if (EVP_CIPHER_CTX_encrypting(ctx) && ((evp_ctx->tls_version) < TLS1_1_VERSION))
-        memcpy(EVP_CIPHER_CTX_iv_noconst(ctx),
+        memmove(EVP_CIPHER_CTX_iv_noconst(ctx),
                evp_ctx->dstBufferList.pBuffers[1].pData + len -
                AES_BLOCK_SIZE, EVP_CIPHER_CTX_iv_length(ctx));
     evp_ctx->payload_length = NO_PAYLOAD_LENGTH_SPECIFIED;
 
     if (!isZeroCopy()) {
-        memcpy(out, evp_ctx->dstFlatBuffer[1].pData, len);
+        memmove(out, evp_ctx->dstFlatBuffer[1].pData, len);
         qaeCryptoMemFree(evp_ctx->srcFlatBuffer[1].pData);
         evp_ctx->srcFlatBuffer[1].pData = NULL;
         evp_ctx->dstFlatBuffer[1].pData = NULL;


### PR DESCRIPTION
When I execute QAT Engine with valgrind,
it says some warnings such as:

==21713== Source and destination overlap in memcpy(0x415fab3, 0x415fab3, 13)
==21713==    at 0x4C2E1DC: memcpy@@GLIBC_2.14 (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==21713==    by 0x69BAE83: qat_aes_cbc_hmac_sha_cipher (qat_ciphers.c:1209)
==21713==    by 0x5C9BE2E: EVP_Cipher (evp_lib.c:231)
==21713==    by 0x58CD710: tls1_enc (ssl3_record.c:894)
==21713==    by 0x58CC468: ssl3_get_record (ssl3_record.c:457)
==21713==    by 0x58CA3D4: ssl3_read_bytes (rec_layer_s3.c:1150)
==21713==    by 0x58F6341: tls_get_message_header (statem_lib.c:450)
==21713==    by 0x58EBCAC: read_state_machine (statem.c:559)
==21713==    by 0x58EBA58: state_machine (statem.c:429)
==21713==    by 0x58EB57B: ossl_statem_accept (statem.c:222)
==21713==    by 0x58E318A: ssl_do_handshake_intern (ssl_lib.c:2996)
==21713==    by 0x5BC0C5D: async_start_func (async.c:198)

To fixup this problem, this patch replaces memcpy to memmove in qat_ciphers.c.